### PR TITLE
Update striped.ts to dotenv standard module

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -6,7 +6,7 @@
     "preact-render-to-string": "https://esm.sh/*preact-render-to-string@5.2.4",
     "@preact/signals": "https://esm.sh/*@preact/signals@1.0.3",
     "@preact/signals-core": "https://esm.sh/*@preact/signals-core@1.0.1",
-    "dotenv": "https://deno.land/x/dotenv@v3.2.0/mod.ts",
+    "dotenv": "https://deno.land/std@0.178.0/dotenv/mod.ts",
     "stripe": "https://esm.sh/stripe@10.15.0?target=deno",
     "@stripe/stripe-js":"https://esm.sh/@stripe/stripe-js@1.35.0"
   }

--- a/utils/striped.ts
+++ b/utils/striped.ts
@@ -1,10 +1,12 @@
-import { config } from "dotenv";
+import { load } from "https://deno.land/std@0.178.0/dotenv/mod.ts";
 import Stripe from "stripe";
+
+const env = await load();
 
 const IS_PRODUCTION = Deno.env.get('DENO_ENV') === 'production';
 
-const stripeSEC = (!IS_PRODUCTION ? config().STRIPE_SEC : (Deno.env.get('STRIPE_SEC') as string));
-export const stripePUB = (!IS_PRODUCTION ? config().STRIPE_PUB : (Deno.env.get('STRIPE_PUB') as string));
+const stripeSEC = (!IS_PRODUCTION ? env['STRIPE_SEC'] : (Deno.env.get('STRIPE_SEC') as string));
+export const stripePUB = (!IS_PRODUCTION ? env['STRIPE_PUB'] : (Deno.env.get('STRIPE_PUB') as string));
 
 export const stripe = new Stripe(stripeSEC, {
     httpClient: Stripe.createFetchHttpClient(),

--- a/utils/striped.ts
+++ b/utils/striped.ts
@@ -1,4 +1,4 @@
-import { load } from "https://deno.land/std@0.178.0/dotenv/mod.ts";
+import { load } from "dotenv";
 import Stripe from "stripe";
 
 const env = await load();


### PR DESCRIPTION
Converted to the Deno dotenv standard module. 

The module https://deno.land/x/dotenv has been deprecated since version 0.127.0